### PR TITLE
Zkillboard doesn't like 'limit' anymore.

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ function upTime(countTo) {
 function refreshKill() {
     var req = new XMLHttpRequest(); // a new request
     var kill;
-    req.open("GET","https://zkillboard.com/api/characterID/96875547/losses/shipTypeID/634/limit/1/",true);
+    req.open("GET","https://zkillboard.com/api/characterID/96875547/losses/shipTypeID/634/",true);
     req.onreadystatechange = function() {
       if (req.readyState == 4) {
         kill = JSON.parse(req.responseText)


### PR DESCRIPTION
"{"error":"Due to abuse of the limit parameter to avoid caches the ability to modify limit has been revoked for all users"}"

We don't actually need it.